### PR TITLE
SpecialPage: Don't eagerly open a primary DB connection

### DIFF
--- a/specials/SpecialPage.php
+++ b/specials/SpecialPage.php
@@ -12,8 +12,6 @@
  */
 namespace HydraCore;
 
-use Wikimedia\Rdbms\DBConnRef;
-
 class SpecialPage extends \SpecialPage {
 	/** @var \WebRequest */
 	protected $wgRequest;
@@ -21,8 +19,6 @@ class SpecialPage extends \SpecialPage {
 	protected $wgUser;
 	/** @var \OutputPage */
 	protected $output;
-	/**@var DBConnRef */
-	protected $DB;
 
 	/**
 	 * @param string $name Name of the special page
@@ -34,7 +30,6 @@ class SpecialPage extends \SpecialPage {
 		$this->wgRequest = $this->getRequest();
 		$this->wgUser    = $this->getUser();
 		$this->output    = $this->getOutput();
-		$this->DB = wfGetDB( DB_PRIMARY );
 	}
 
 	/**


### PR DESCRIPTION
HydraCore's base SpecialPage class eagerly opens a primary DB connection
in its constructor, which ends up having an outsized effect because
GlobalShortcuts instantiates all special pages for logged-in users on
every pageview. None of the subclasses seem to actually use this
connection handle, so let's remove it.