### PR TITLE
PLATFORM-7959 Remove 'withads' param that's been broken for a while now

### DIFF
--- a/HydraCoreHooks.php
+++ b/HydraCoreHooks.php
@@ -1,9 +1,6 @@
 <?php
 
-use MediaWiki\Api\Hook\APIAfterExecuteHook;
-use MediaWiki\Api\Hook\APIGetAllowedParamsHook;
 use MediaWiki\Api\Hook\APIGetDescriptionMessagesHook;
-use MediaWiki\Api\Hook\APIGetParamDescriptionMessagesHook;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 
 /**
@@ -19,30 +16,19 @@ use MediaWiki\Hook\ParserFirstCallInitHook;
  *
  */
 class HydraCoreHooks implements
-	APIGetAllowedParamsHook,
 	APIGetDescriptionMessagesHook,
-	APIGetParamDescriptionMessagesHook,
-	ParserFirstCallInitHook,
-	APIAfterExecuteHook
+	ParserFirstCallInitHook
 {
 
-	public function __construct(private HydraCore $core) {
+	public function __construct( private HydraCore $core ) {
 	}
 
 	/**
 	 * Force X-Mobile header.
 	 */
-	public static function onBeforePageDisplayMobile( $output, $skin ): void {
+	public function onBeforePageDisplayMobile( $output, $skin ): void {
 		$response = $output->getRequest()->response();
 		$response->header( "X-Mobile: true" );
-	}
-
-	/**
-	 * Add hooks late so that they are ensured to come last.
-	 */
-	public static function addLateHooks(): void {
-		global $wgHooks;
-		$wgHooks['APIAfterExecute'][] = 'HydraCoreHooks::onAPIAfterExecute';
 	}
 
 	/**
@@ -50,32 +36,6 @@ class HydraCoreHooks implements
 	 */
 	public function onParserFirstCallInit( $parser ): void {
 		$parser->setFunctionHook( 'numberofcontributors', [$this->core, 'numberOfContributors'] );
-	}
-
-	/**
-	 * APIGetAllowedParams hook handler
-	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/APIGetAllowedParams
-	 * @param ApiBase &$module
-	 * @param array|bool &$params
-	 */
-	public function onAPIGetAllowedParams( $module, &$params, $flags ): void {
-		if ( $module->getModuleName() == 'parse' ) {
-			$params['withads'] = false;
-		}
-	}
-
-	/**
-	 * APIGetParamDescriptionMessages hook handler
-	 *
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/APIGetParamDescriptionMessages
-	 * @param ApiBase $module
-	 * @param array|bool &$msgs
-	 */
-	public function onAPIGetParamDescriptionMessages( $module, &$msgs ): void {
-		if ( $module->getModuleName() == 'parse' ) {
-			$msgs['withads'] = [ $module->msg( 'api-parse-withads-desc' ) ];
-		}
 	}
 
 	/**
@@ -88,41 +48,6 @@ class HydraCoreHooks implements
 	public function onAPIGetDescriptionMessages( $module, &$msgs ): void {
 		if ( $module->getModuleName() == 'parse' ) {
 			$msgs[] = $module->msg( 'api-parse-modified-hydracore' );
-		}
-	}
-
-	/**
-	 * APIAfterExecute hook handler
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/
-	 * @param ApiBase &$module
-	 * @throws ApiUsageException
-	 */
-	public function onAPIAfterExecute( $module ): void {
-		if ( $module->getModuleName() == 'parse' ) {
-			$data = $module->getResult()->getResultData();
-			$params = $module->extractRequestParams();
-			if ( isset( $data['parse']['text'] ) && $params['withads'] ) {
-				$result = $module->getResult();
-				$result->reset();
-
-				$text = $data['parse']['text'];
-				if ( is_array( $text ) ) {
-					if ( defined( 'ApiResult::META_CONTENT' ) &&
-						 isset( $text[ApiResult::META_CONTENT] )
-					) {
-						$contentKey = $text[ApiResult::META_CONTENT];
-					} else {
-						$contentKey = '*';
-					}
-					$text = $text[$contentKey];
-				}
-
-				$data['parse']['text'] =
-					'<div id="mobileatfmrec">' . HydraHooks::getAdBySlot( 'mobileatfmrec' ) . '</div>' . $text .
-					'<div id="mobilebtfmrec">' . HydraHooks::getAdBySlot( 'mobilebtfmrec' ) . '</div>';
-
-				$result->addValue( null, $module->getModuleName(), $data['parse'] );
-			}
 		}
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -140,15 +140,9 @@
 		"localBasePath": "",
 		"remoteExtPath": "HydraCore"
 	},
-	"ExtensionFunctions": [
-		"HydraCoreHooks::addLateHooks"
-	],
 	"Hooks": {
-		"APIAfterExecute": "main",
-		"APIGetAllowedParams": "main",
 		"APIGetDescriptionMessages": "main",
-		"APIGetParamDescriptionMessages": "main",
-		"BeforePageDisplayMobile": "HydraCoreHooks::onBeforePageDisplayMobile",
+		"BeforePageDisplayMobile": "main",
 		"ParserFirstCallInit": "main"
 	},
 	"HookHandlers": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -87,6 +87,5 @@
 	"gamepedia-support-url": "https://support.fandom.com",
 	"noticeboard": "Admin noticeboard",
 	"noticeboard-url": "Project:Admin noticeboard",
-	"api-parse-withads-desc": "Add advertisements to output.",
 	"api-parse-modified-hydracore": "Extended by HydraCore"
 }


### PR DESCRIPTION
This PR:
* fixes the issue with the upgraded code when calling api.php on a Gamepedia wiki

when calling https://games-pedias.mturek-18.fandom-dev.pl/api.php:

```
{
    "error": {
        "code": "internal_api_error_Error",
        "info": "[2405146559e5009e9790fb64] Exception caught: Non-static method HydraCoreHooks::onAPIAfterExecute() cannot be called statically",
        "errorclass": "Error",
        "*": "Error at /usr/wikia/mw139/current/src/includes/HookContainer/HookContainer.php(338)\nfrom /usr/wikia/mw139/current/src/includes/HookContainer/HookContainer.php(338)\n#0 /usr/wikia/mw139/current/src/includes/HookContainer/HookContainer.php(137): MediaWiki\\HookContainer\\HookContainer->callLegacyHook(string, array, array, array)\n#1 /usr/wikia/mw139/current/src/includes/api/ApiHookRunner.php(66): MediaWiki\\HookContainer\\HookContainer->run(string, array)\n#2 /usr/wikia/mw139/current/src/includes/api/ApiMain.php(1901): MediaWiki\\Api\\ApiHookRunner->onAPIAfterExecute(ApiHelp)\n#3 /usr/wikia/mw139/current/src/includes/api/ApiMain.php(875): ApiMain->executeAction()\n#4 /usr/wikia/mw139/current/src/includes/api/ApiMain.php(846): ApiMain->executeActionWithErrorHandling()\n#5 /usr/wikia/mw139/current/src/api.php(90): ApiMain->execute()\n#6 /usr/wikia/mw139/current/src/api.php(45): wfApiMain()\n#7 {main}"
    }
}
```

* guts the 'withads' functionality that's been broken since at least the last upgrade (likely since the wikis were migrated to UCP), see https://fandom.slack.com/archives/C51GR86SJ/p1678716730640989

Calling https://minecraft.fandom.com/api.php?action=parse&withads=true will yield
```
{
    "error": {
        "code": "internal_api_error_Error",
        "info": "[14a1b8c7add2a696] Caught exception of type Error",
        "errorclass": "Error"
    }
}
```
in logs
```
Error from line 106 of /extensions/HydraCore/HydraCore.hooks.php: Class "HydraHooks" not found 	#0 /includes/HookContainer/HookContainer.php(338): HydraCoreHooks::onAPIAfterExecute(ApiParse) 	#1 /includes/HookContainer/HookContainer.php(137): MediaWiki\HookContainer\HookContainer->callLegacyHook(string, array, array, array) 	#2 /includes/api/ApiHookRunner.php(66): MediaWiki\HookContainer\HookContainer->run(string, array) 	#3 /includes/api/ApiMain.php(1875): MediaWiki\Api\ApiHookRunner->onAPIAfterExecute(ApiParse) 	#4 /includes/api/ApiMain.php(853): ApiMain->executeAction() 	#5 /includes/api/ApiMain.php(824): ApiMain->executeActionWithErrorHandling() 	#6 /api.php(90): ApiMain->execute() 	#7 /api.php(45): wfApiMain() 	#8 {main}
```
since there are no such logs on prod (besides my calls), we can be safely sure it's not called in prod.



