### PR TITLE
PLATFORM-7909 Move numberofcontributors to Cheevos

### DIFF
--- a/HydraCoreHooks.php
+++ b/HydraCoreHooks.php
@@ -16,12 +16,8 @@ use MediaWiki\Hook\ParserFirstCallInitHook;
  *
  */
 class HydraCoreHooks implements
-	APIGetDescriptionMessagesHook,
-	ParserFirstCallInitHook
+	APIGetDescriptionMessagesHook
 {
-
-	public function __construct( private HydraCore $core ) {
-	}
 
 	/**
 	 * Force X-Mobile header.
@@ -29,13 +25,6 @@ class HydraCoreHooks implements
 	public function onBeforePageDisplayMobile( $output, $skin ): void {
 		$response = $output->getRequest()->response();
 		$response->header( "X-Mobile: true" );
-	}
-
-	/**
-	 * Setup all the parser functions
-	 */
-	public function onParserFirstCallInit( $parser ): void {
-		$parser->setFunctionHook( 'numberofcontributors', [$this->core, 'numberOfContributors'] );
 	}
 
 	/**

--- a/ServiceWiring.php
+++ b/ServiceWiring.php
@@ -7,10 +7,7 @@ use MediaWiki\MediaWikiServices;
 
 return [
 	HydraCore::class => static function ( MediaWikiServices $services ): HydraCore {
-		return new HydraCore(
-			$services->getMainWANObjectCache(),
-			$services->getDBLoadBalancer(),
-		);
+		return new HydraCore();
 	},
 	Font::class => static function ( MediaWikiServices $services ): Font {
 		return new Font(

--- a/classes/HydraCore.php
+++ b/classes/HydraCore.php
@@ -1,19 +1,11 @@
 <?php
 
-use Wikimedia\Rdbms\ILoadBalancer;
-
-
 /**
  * Collection of basic utility functions
  * @author Noah Manneschmidt
  */
 
 class HydraCore {
-	public function __construct(
-		private WANObjectCache $cache,
-		private ILoadBalancer $loadBalancer
-	) {
-	}
 
 	/**
 	 * Inserts new elements into a string indexed array at a specific point
@@ -107,30 +99,6 @@ class HydraCore {
 		}
 		$extraAttribs['class'] = 'fa fa-' . $name;
 		return Html::element( 'span', $extraAttribs );
-	}
-
-	/**
-	 * Returns the number of users who have made at least one edit on the wiki.
-	 */
-	public function numberOfContributors() {
-		$key = $this->cache->makeKey( 'NumberOfContributors' );
-		$hit = $this->cache->get( $key );
-		if ( !$hit ) {
-			$actorQuery = [ 'tables' => [], 'joins' => [] ];
-			$userField = 'rev_user';
-
-			$db = $this->loadBalancer->getConnection( DB_REPLICA );
-			$hit = $db->selectField(
-				[ 'revision' ] + $actorQuery['tables'],
-				"count(distinct $userField)",
-				'',
-				__METHOD__,
-				[],
-				$actorQuery['joins']
-			);
-			$this->cache->set( $key, $hit, 3600 );
-		}
-		return $hit;
 	}
 
 	/**

--- a/extension.json
+++ b/extension.json
@@ -142,15 +142,11 @@
 	},
 	"Hooks": {
 		"APIGetDescriptionMessages": "main",
-		"BeforePageDisplayMobile": "main",
-		"ParserFirstCallInit": "main"
+		"BeforePageDisplayMobile": "main"
 	},
 	"HookHandlers": {
 		"main": {
-			"class": "HydraCoreHooks",
-			"services": [
-				"HydraCore"
-			]
+			"class": "HydraCoreHooks"
 		}
 	},
 	"ServiceWiringFiles": ["ServiceWiring.php"],


### PR DESCRIPTION
This functionality is only used in Cheevos. It will be much easier to upgrade HydraCore if it doesn't have unrelated code that can be tested only in context of other extensions.